### PR TITLE
fix subtraction treated as binary operator

### DIFF
--- a/lib/cidr.rb
+++ b/lib/cidr.rb
@@ -811,7 +811,7 @@ end
             my_ip = my_ip + bitstep
             change_mask = @hostmask | my_ip
             if (limit)
-                limit = limit -1
+                limit = limit - 1
                 break if (limit == 0)
             end
         end

--- a/lib/methods.rb
+++ b/lib/methods.rb
@@ -492,7 +492,7 @@ def range(lower, upper, options=nil)
 
             my_ip = my_ip + bitstep
             if (limit)
-                limit = limit -1
+                limit = limit - 1
                 break if (limit == 0)
             end
         end


### PR DESCRIPTION
Receiving the following errors from jruby 9.0.1.0.  Seems like an easy fix.  Passes `cidr_test` and `methods_test` after change.

```
/usr/local/bundle/gems/netaddr-1.5.1/lib/methods.rb:495: warning: `-' after local variable or literal is interpreted as binary operator
/usr/local/bundle/gems/netaddr-1.5.1/lib/methods.rb:495: warning: even though it seems like unary operator
/usr/local/bundle/gems/netaddr-1.5.1/lib/cidr.rb:814: warning: `-' after local variable or literal is interpreted as binary operator
/usr/local/bundle/gems/netaddr-1.5.1/lib/cidr.rb:814: warning: even though it seems like unary operator
```
