### PR TITLE
Add each method to ipnet

### DIFF
--- a/lib/ipnet.rb
+++ b/lib/ipnet.rb
@@ -1,0 +1,8 @@
+module NetAddr
+
+	# IPNet represents an IP network. It must be subclassed by IPv*Net
+	class IPNet
+
+	end # class IPNet
+
+end # module

--- a/lib/ipnet.rb
+++ b/lib/ipnet.rb
@@ -13,6 +13,16 @@ module NetAddr
 			return self
 		end
 
+		# Yield all IP of the network that are host IP and return self.
+		# Return an enumerator if no block are given.
+		def each_host()
+			return to_enum(:each_host) unless block_given?
+			1.upto(self.len - 2) do |idx|
+				yield nth(idx)
+			end
+			return self
+		end
+
 	end # class IPNet
 
 end # module

--- a/lib/ipnet.rb
+++ b/lib/ipnet.rb
@@ -3,6 +3,16 @@ module NetAddr
 	# IPNet represents an IP network. It must be subclassed by IPv*Net
 	class IPNet
 
+		# Yield all IP of the network and return self.
+		# Return an enumerator if no block are given.
+		def each()
+			return to_enum(:each) unless block_given?
+			0.upto(self.len - 1) do |idx|
+				yield nth(idx)
+			end
+			return self
+		end
+
 	end # class IPNet
 
 end # module

--- a/lib/ipnet.rb
+++ b/lib/ipnet.rb
@@ -23,6 +23,23 @@ module NetAddr
 			return self
 		end
 
+		# Yield of subnet of the given length and return self.
+		# Return an enumerator if no block are given.
+		# Never yield if prefix_len is invalid.
+		#
+		# arguments:
+		# * prefix_len prefix of the new network.
+		def each_subnet(prefix_len)
+			return to_enum(:each_subnet, prefix_len) unless block_given?
+			count = self.subnet_count(prefix_len)
+			unless count == 0 then
+				0.upto(count - 1) do |idx|
+					yield nth_subnet(prefix_len, idx)
+				end
+			end
+			return self
+		end
+
 	end # class IPNet
 
 end # module

--- a/lib/ipv4net.rb
+++ b/lib/ipv4net.rb
@@ -1,7 +1,9 @@
+require_relative 'ipnet.rb'
+
 module NetAddr
 	
 	#IPv4Net represents an IPv4 network. 
-	class IPv4Net
+	class IPv4Net < IPNet
 		
 		#arguments:
 		#* ip - an IPv4 object

--- a/lib/ipv6net.rb
+++ b/lib/ipv6net.rb
@@ -1,7 +1,9 @@
+require_relative 'ipnet.rb'
+
 module NetAddr
 	
 	#IPv6Net represents an IPv6 network. 
-	class IPv6Net
+	class IPv6Net < IPNet
 		
 		#arguments:
 		#* ip - an IPv6 object

--- a/test/examples.rb
+++ b/test/examples.rb
@@ -33,11 +33,15 @@ class NetAddrExamples < Test::Unit::TestCase
 		subnet30 = net.nth_subnet(30,2)
 		assert_equal("10.0.0.8/30", subnet30.to_s)
 		puts "  " + subnet30.to_s
+
+		puts "\nGet the first IP of the /30"
+		expect = '10.0.0.8'
+		ip = subnet30.nth(0)
+		assert_equal(expect, ip.to_s)
 		
 		puts "\nIterating the IPs of the /30"
 		expect = ["10.0.0.8","10.0.0.9","10.0.0.10","10.0.0.11"]
-		0.upto(subnet30.len - 1) do |i|
-			ip = subnet30.nth(i)
+		subnet30.each.with_index do |ip, i|
 			assert_equal(expect[i], ip.to_s)
 			puts "  " + ip.to_s
 		end
@@ -120,7 +124,19 @@ class NetAddrExamples < Test::Unit::TestCase
 			assert_equal(expect[i], ip.to_s)
 			puts "  " + ip.to_s
 		end
-		
+
+		puts "\nIts first /126 subnet:"
+		subnet126 = subnet64.nth_subnet(126,0)
+		assert_equal("fec0:0:0:2::/126", subnet126.to_s)
+		puts "  " + subnet126.to_s
+
+		puts "\nIterating the IPs of the /126"
+		expect = ["fec0:0:0:2::","fec0:0:0:2::1","fec0:0:0:2::2","fec0:0:0:2::3"]
+		subnet126.each.with_index do |ip, i|
+			assert_equal(expect[i], ip.to_s)
+			puts "  " + ip.to_s
+		end
+
 		puts "\nGiven the 3rd /64 of fec0::/62, fill in the holes:"
 		expect = ["fec0::/63", "fec0:0:0:2::/64","fec0:0:0:3::/64"]
 		i = 0

--- a/test/examples.rb
+++ b/test/examples.rb
@@ -45,6 +45,13 @@ class NetAddrExamples < Test::Unit::TestCase
 			assert_equal(expect[i], ip.to_s)
 			puts "  " + ip.to_s
 		end
+
+		puts "\nIterating the host IPs of the /30"
+		expect = ["10.0.0.9","10.0.0.10"]
+		subnet30.each_host.with_index do |ip, i|
+			assert_equal(expect[i], ip.to_s)
+			puts "  " + ip.to_s
+		end
 		
 		puts "\nDoes 10.0.0.7 belong to the 10.0.0.8/29 subnet?"
 		subnet29 = NetAddr::IPv4Net.parse("10.0.0.8/29")
@@ -133,6 +140,13 @@ class NetAddrExamples < Test::Unit::TestCase
 		puts "\nIterating the IPs of the /126"
 		expect = ["fec0:0:0:2::","fec0:0:0:2::1","fec0:0:0:2::2","fec0:0:0:2::3"]
 		subnet126.each.with_index do |ip, i|
+			assert_equal(expect[i], ip.to_s)
+			puts "  " + ip.to_s
+		end
+
+		puts "\nIterating the host IPs of the /126"
+		expect = ["fec0:0:0:2::1","fec0:0:0:2::2"]
+		subnet126.each_host.with_index do |ip, i|
 			assert_equal(expect[i], ip.to_s)
 			puts "  " + ip.to_s
 		end

--- a/test/examples.rb
+++ b/test/examples.rb
@@ -23,8 +23,7 @@ class NetAddrExamples < Test::Unit::TestCase
 		
 		puts "\nIterating its /26 subnets:"
 		expect = ["10.0.0.0/26","10.0.0.64/26","10.0.0.128/26","10.0.0.192/26"]
-		0.upto(net.subnet_count(26) - 1) do |i|
-			subnet = net.nth_subnet(26,i)
+		net.each_subnet(26).with_index do |subnet, i|
 			assert_equal(expect[i], subnet.to_s)
 			puts "  " + subnet.to_s
 		end
@@ -113,8 +112,7 @@ class NetAddrExamples < Test::Unit::TestCase
 		
 		puts "\nIterating its /64 subnets:"
 		expect = ["fec0::/64","fec0:0:0:1::/64","fec0:0:0:2::/64","fec0:0:0:3::/64"]
-		0.upto(net.subnet_count(64) - 1) do |i|
-			subnet = net.nth_subnet(64,i)
+		net.each_subnet(64).with_index do |subnet, i|
 			assert_equal(expect[i], subnet.to_s)
 			puts "  " + subnet.to_s
 		end

--- a/test/ipv4net_test.rb
+++ b/test/ipv4net_test.rb
@@ -135,6 +135,17 @@ class TestIPv4Net < Test::Unit::TestCase
 		assert_nil(NetAddr::IPv4Net.parse("1.1.1.0/24").nth_subnet(26,-1))
 		assert_nil(NetAddr::IPv4Net.parse("1.1.1.0/24").nth_subnet(24,0))
 	end
+
+	def test_each_subnet
+		expect = ['1.1.1.0/26', '1.1.1.64/26', '1.1.1.128/26', '1.1.1.192/26']
+		assert_equal(expect, NetAddr::IPv4Net.parse("1.1.1.0/24").each_subnet(26).map{|e| e.to_s})
+
+		expect = []
+		assert_equal(expect, NetAddr::IPv4Net.parse("1.1.1.0/26").each_subnet(26).map{|e| e.to_s})
+
+		expect = []
+		assert_equal(expect, NetAddr::IPv4Net.parse("1.1.1.0/28").each_subnet(26).map{|e| e.to_s})
+	end
 	
 	def test_prev
 		assert_equal("1.0.0.0/29", NetAddr::IPv4Net.parse("1.0.0.8/30").prev.to_s)

--- a/test/ipv4net_test.rb
+++ b/test/ipv4net_test.rb
@@ -116,6 +116,17 @@ class TestIPv4Net < Test::Unit::TestCase
 		expect = ['1.1.1.0', '1.1.1.1', '1.1.1.2', '1.1.1.3']
 		assert_equal(expect, NetAddr::IPv4Net.parse("1.1.1.0/30").each.map{|e| e.to_s})
 	end
+
+	def test_each_host
+		expect = ['1.1.1.1', '1.1.1.2']
+		assert_equal(expect, NetAddr::IPv4Net.parse("1.1.1.0/30").each_host.map{|e| e.to_s})
+
+		expect = []
+		assert_equal(expect, NetAddr::IPv4Net.parse("1.1.1.0/31").each_host.map{|e| e.to_s})
+
+		expect = []
+		assert_equal(expect, NetAddr::IPv4Net.parse("1.1.1.0/32").each_host.map{|e| e.to_s})
+	end
 	
 	def test_nth_subnet
 		assert_equal("1.1.1.0/26", NetAddr::IPv4Net.parse("1.1.1.0/24").nth_subnet(26,0).to_s)

--- a/test/ipv4net_test.rb
+++ b/test/ipv4net_test.rb
@@ -111,6 +111,11 @@ class TestIPv4Net < Test::Unit::TestCase
 		assert_equal("1.1.1.1", NetAddr::IPv4Net.parse("1.1.1.0/26").nth(1).to_s)
 		assert_nil(NetAddr::IPv4Net.parse("1.1.1.0/26").nth(64))
 	end
+
+	def test_each
+		expect = ['1.1.1.0', '1.1.1.1', '1.1.1.2', '1.1.1.3']
+		assert_equal(expect, NetAddr::IPv4Net.parse("1.1.1.0/30").each.map{|e| e.to_s})
+	end
 	
 	def test_nth_subnet
 		assert_equal("1.1.1.0/26", NetAddr::IPv4Net.parse("1.1.1.0/24").nth_subnet(26,0).to_s)

--- a/test/ipv6net_test.rb
+++ b/test/ipv6net_test.rb
@@ -99,6 +99,17 @@ class TestIPv6Net < Test::Unit::TestCase
 		expect = ['::', '::1', '::2', '::3']
 		assert_equal(expect, NetAddr::IPv6Net.parse('::/126').each.map{|e| e.to_s})
 	end
+
+	def test_each_host
+		expect = ['::1', '::2']
+		assert_equal(expect, NetAddr::IPv6Net.parse('::/126').each_host.map{|e| e.to_s})
+
+		expect = []
+		assert_equal(expect, NetAddr::IPv6Net.parse('::/127').each_host.map{|e| e.to_s})
+
+		expect = []
+		assert_equal(expect, NetAddr::IPv6Net.parse('::/128').each_host.map{|e| e.to_s})
+	end
 	
 	def test_nth_subnet
 		assert_equal("1::/30", NetAddr::IPv6Net.parse("1::/24").nth_subnet(30,0).to_s)

--- a/test/ipv6net_test.rb
+++ b/test/ipv6net_test.rb
@@ -115,6 +115,15 @@ class TestIPv6Net < Test::Unit::TestCase
 		assert_equal("1::/30", NetAddr::IPv6Net.parse("1::/24").nth_subnet(30,0).to_s)
 		assert_nil(NetAddr::IPv6Net.parse("1::").nth_subnet(26,4))
 	end
+
+	def test_each_subnet
+		expect = ["1::/30", "1:4::/30", "1:8::/30", "1:c::/30"]
+		assert_equal(expect, NetAddr::IPv6Net.parse("1::/28").each_subnet(30).map{|e| e.to_s})
+		expect = []
+		assert_equal(expect, NetAddr::IPv6Net.parse("1::/30").each_subnet(30).map{|e| e.to_s})
+		expect = []
+		assert_equal(expect, NetAddr::IPv6Net.parse("1::/32").each_subnet(30).map{|e| e.to_s})
+	end
 	
 	def test_prev
 		assert_equal("1::/125", NetAddr::IPv6Net.parse("1::8/126").prev.to_s)

--- a/test/ipv6net_test.rb
+++ b/test/ipv6net_test.rb
@@ -94,6 +94,11 @@ class TestIPv6Net < Test::Unit::TestCase
 		assert_equal("::1", NetAddr::IPv6Net.parse("::/127").nth(1).to_s)
 		assert_nil(NetAddr::IPv6Net.parse("::/127").nth(2))
 	end
+
+	def test_each
+		expect = ['::', '::1', '::2', '::3']
+		assert_equal(expect, NetAddr::IPv6Net.parse('::/126').each.map{|e| e.to_s})
+	end
 	
 	def test_nth_subnet
 		assert_equal("1::/30", NetAddr::IPv6Net.parse("1::/24").nth_subnet(30,0).to_s)


### PR DESCRIPTION
It would be easier to be able to iterate over IPv*Net objects.

This is implementing by the current pull request.