### PR TITLE
Fix integer conversion in masks

### DIFF
--- a/lib/mask128.rb
+++ b/lib/mask128.rb
@@ -30,7 +30,9 @@ module NetAddr
 			if (mask.start_with?("/")) # cidr format
 				mask = mask[1..-1] # remove "/"
 			end
-			return Mask128.new(mask.to_i)
+			return Mask128.new(Integer(mask))
+		rescue ArgumentError
+			raise ValidationError, "#{mask} is not valid integer."
 		end
 		
 		#cmp compares equality with another Mask128. Return:

--- a/lib/mask32.rb
+++ b/lib/mask32.rb
@@ -28,9 +28,15 @@ module NetAddr
 		def Mask32.parse(mask)
 			mask.strip!
 			if (mask.start_with?("/")) # cidr format
-				return Mask32.new(mask[1..-1].to_i) # remove "/"
-			elsif (!mask.include?("."))
-				return Mask32.new(mask.to_i)
+				mask = mask[1..-1] # remove "/"
+			end
+
+			if (!mask.include?("."))
+				begin
+					return Mask32.new(Integer(mask))
+				rescue ArgumentError
+					raise ValidationError, "#{mask} is not valid integer."
+				end
 			end
 			
 			# for extended netmask


### PR DESCRIPTION
At the moment, parse functions in Mask32 and Mask128 convert strings
into integers using to_i function, which is dangerous because it
silently accepts inputs like 'aaa' as 0.

With this PR, they switch to use Integer function, which throws
ArgumentError if invalid input is passed. We catch ArgumentError and
throw ValidationError to user instead.