### PR TITLE
Fix support for ipv4-embedded ipv6 networks

### DIFF
--- a/lib/netaddr.rb
+++ b/lib/netaddr.rb
@@ -48,10 +48,10 @@ module NetAddr
 	
 	## parse_net parses a string into an IPv4Net or IPv6Net
 	def parse_net(net)
-		if (net.include?(".")) # ipv4
-			return IPv4Net.parse(net)
+		if (net.include?(":"))
+			return IPv6Net.parse(net)
 		end
-		return IPv6Net.parse(net)
+		return IPv4Net.parse(net)
 	end
 	module_function :parse_net
 	

--- a/test/netaddr_test.rb
+++ b/test/netaddr_test.rb
@@ -13,6 +13,7 @@ class TestNetAddr < Test::Unit::TestCase
 	def test_parse_net
 		assert_equal("128.0.0.1/32", NetAddr.parse_net("128.0.0.1/32").to_s)
 		assert_equal("1::/24", NetAddr.parse_net("1::1/24").to_s)
+		assert_equal("1::aabb:ccdd/128", NetAddr.parse_net("1::170.187.204.221/128").to_s)
 	end
 	
 	def test_ipv4_prefix_len


### PR DESCRIPTION
Currently, IPv4-embedded IPv6 networks in CIDR notation are getting misclassified as IPv4 networks and failing validation within `parse_net`

In rfc4291 2.3, the text representation is defined as `ipv6-address/prefix-length` where `ipv6-address` is any of the notations listed in rfc4291 2.2, including `x:x:x:x:x:x:d.d.d.d`, so `1::170.187.204.221/128` and similar should be considered a valid CIDR. 

This change simply aligns `parse_net` with `parse_ip`'s method of determining the ip type