### PR TITLE
Remove recursion to allow large IPv4Net data sets.

### DIFF
--- a/lib/ipv4.rb
+++ b/lib/ipv4.rb
@@ -2,6 +2,8 @@ module NetAddr
 	
 	#IPv4 represents a single IPv4 address. 
 	class IPv4
+		include Comparable
+
 		# addr is the Integer representation of this IP address
 		attr_reader :addr
 		
@@ -39,6 +41,8 @@ module NetAddr
 			end
 			return 0
 		end
+		
+		alias :"<=>" :cmp
 		
 		# multicast_mac returns the EUI48 multicast mac-address for this IP.
 		# It will return the zero address for IPs outside of the multicast range 224.0.0.0/4.

--- a/lib/ipv4net.rb
+++ b/lib/ipv4net.rb
@@ -2,6 +2,7 @@ module NetAddr
 	
 	#IPv4Net represents an IPv4 network. 
 	class IPv4Net
+		include Comparable
 		
 		#arguments:
 		#* ip - an IPv4 object
@@ -60,6 +61,8 @@ module NetAddr
 			end
 			return self.netmask.cmp(other.netmask)
 		end
+		
+		alias :"<=>" :cmp
 		
 		#contains returns true if the IPv4Net contains the IPv4
 		def contains(ip)

--- a/lib/ipv6.rb
+++ b/lib/ipv6.rb
@@ -2,6 +2,8 @@ module NetAddr
 	
 	#IPv6 represents a single IPv6 address. 
 	class IPv6
+		include Comparable
+
 		# addr is the Integer representation of this IP address
 		attr_reader :addr
 		
@@ -39,6 +41,8 @@ module NetAddr
 			end
 			return 0
 		end
+		
+		alias :"<=>" :cmp
 		
 		# ipv4 generates an IPv4 from an IPv6 address. The IPv4 address is generated based on the mechanism described by RFC 6052.
 		# The argument pl (prefix length) should be one of: 32, 40, 48, 56, 64, or 96. Default is 96 unless one of the supported values is provided.

--- a/lib/ipv6net.rb
+++ b/lib/ipv6net.rb
@@ -2,6 +2,7 @@ module NetAddr
 	
 	#IPv6Net represents an IPv6 network. 
 	class IPv6Net
+		include Comparable
 		
 		#arguments:
 		#* ip - an IPv6 object
@@ -56,6 +57,8 @@ module NetAddr
 			end
 			return self.netmask.cmp(other.netmask)
 		end
+		
+		alias :"<=>" :cmp
 		
 		#contains returns true if the IPv6Net contains the IPv6
 		def contains(ip)

--- a/lib/netaddr.rb
+++ b/lib/netaddr.rb
@@ -62,7 +62,7 @@ module NetAddr
 			raise ArgumentError, "Expected an Array for 'list' but got a #{list.class}."
 		end
 		filtered = Util.filter_IPv4(list)
-		return Util.quick_sort(filtered)
+		return filtered.sort
 	end
 	module_function :sort_IPv4
 	
@@ -73,7 +73,7 @@ module NetAddr
 			raise ArgumentError, "Expected an Array for 'list' but got a #{list.class}."
 		end
 		filtered = Util.filter_IPv6(list)
-		return Util.quick_sort(filtered)
+		return filtered.sort
 	end
 	module_function :sort_IPv6
 	
@@ -84,7 +84,7 @@ module NetAddr
 			raise ArgumentError, "Expected an Array for 'list' but got a #{list.class}."
 		end
 		filtered = Util.filter_IPv4Net(list)
-		return Util.quick_sort(filtered)
+		return filtered.sort
 	end
 	module_function :sort_IPv4Net
 	
@@ -95,7 +95,7 @@ module NetAddr
 			raise ArgumentError, "Expected an Array for 'list' but got a #{list.class}."
 		end
 		filtered = Util.filter_IPv6Net(list)
-		return Util.quick_sort(filtered)
+		return filtered.sort
 	end
 	module_function :sort_IPv6Net
 	

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -57,7 +57,7 @@ module NetAddr
 				subs.push(sub)
 			end
 		end
-		subs = quick_sort(subs)
+		subs.sort!
 		
 		filled = []
 		if (subs.length > 0)
@@ -306,37 +306,9 @@ module NetAddr
 		return ipInt
 	end
 		
-	# quick_sort will return a sorted copy of the provided Array.
-	# The array must contain only objects which implement a cmp method and which are comparable to each other.
-	def Util.quick_sort(list)
-		if (list.length <= 1)
-			return [].concat(list)
-		end
-		
-		final_list = []
-		lt_list = []
-		gt_list = []
-		eq_list = []
-		pivot = list[list.length-1]
-		list.each do |ip|
-			cmp = pivot.cmp(ip)
-			if (cmp == 1)
-				lt_list.push(ip)
-			elsif (cmp == -1)
-				gt_list.push(ip)
-			else
-				eq_list.push(ip)
-			end
-		end
-		final_list.concat( quick_sort(lt_list) )
-		final_list.concat(eq_list)
-		final_list.concat( quick_sort(gt_list) )
-		return final_list
-	end
-	
 	# summ_peers returns a copy of the list with any merge-able subnets summ'd together.
 	def Util.summ_peers(list)
-		summd = quick_sort(list)
+		summd = list.sort
 		while true do
 			list_len = summd.length
 			last = list_len - 1

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -11,7 +11,7 @@ module NetAddr
 		cur = ipnet
 		while true do
 			net = cur.prev
-			if (net == nil || net.network.addr < limit)
+			if (net.nil? || net.network.addr < limit)
 				break
 			end
 			nets.unshift(net)
@@ -128,11 +128,11 @@ module NetAddr
 	def Util.fwdfill(ipnet,supernet,limit)
 		nets = [ipnet]
 		cur = ipnet
-		if (limit != nil) # if limit, then fill gaps between net and limit
+		if (!limit.nil?) # if limit, then fill gaps between net and limit
 			while true do
 				nextSub = cur.next()
 				# ensure we've not exceed the total address space
-				if (nextSub == nil)
+				if (nextSub.nil?)
 					break
 				end
 				# ensure we've not exceeded the address space of supernet
@@ -188,7 +188,7 @@ module NetAddr
 			while true do
 				nextSub = cur.next()
 				# ensure we've not exceed the total address space
-				if (nextSub == nil)
+				if (nextSub.nil?)
 					break
 				end
 				# ensure we've not exceeded the address space of supernet

--- a/test/netaddr_test.rb
+++ b/test/netaddr_test.rb
@@ -102,6 +102,34 @@ class TestNetAddr < Test::Unit::TestCase
 			assert_equal(expect[i],net.to_s)
 			i += 1
 		end
+		
+		if ENV['REALLY_SLOW_TEST'] == "true"
+			nets = []
+			(0..31).each do |third|
+				(0..255).each do |fourth|
+					nets.push(NetAddr::IPv4Net.parse("0.0.#{third}.#{fourth}/32"))
+				end
+			end
+			expect = ["0.0.0.0/19"]
+			puts "\nIPv4Net: Summing #{nets.count} IPv4Nets via NetAddr.summ_IPv4Net(). Result: #{expect}."
+			i = 0
+			NetAddr.summ_IPv4Net(nets).each do |net|
+				assert_equal(expect[i],net.to_s)
+				i += 1
+			end
+		end
+		
+		nets = []
+		unrelated = ["10.0.0.0/30", "10.0.1.0/30", "10.0.2.0/30", "10.0.3.0/30"]
+		unrelated.each do |net|
+			nets.push(NetAddr::IPv4Net.parse(net))
+		end
+		expect = unrelated
+		i = 0
+		NetAddr.summ_IPv4Net(nets).each do |net|
+			assert_equal(expect[i],net.to_s)
+			i += 1
+		end
 	end
 	
 	def test_sort_IPv6

--- a/test/netaddr_test.rb
+++ b/test/netaddr_test.rb
@@ -43,6 +43,19 @@ class TestNetAddr < Test::Unit::TestCase
 		sorted = NetAddr.sort_IPv4Net(nets)
 		expect = [nets[1],nets[4],nets[0],nets[2],nets[3]]
 		assert_equal(expect, sorted)
+
+		nets = []
+		(0..31).each do |third|
+			(0..255).each do |fourth|
+				nets.push(NetAddr::IPv4Net.parse("0.0.#{third}.#{fourth}/32"))
+			end
+		end
+		sorted = NetAddr.sort_IPv4Net(nets)
+		expect = nets
+		puts "\nIPv4Net: Sorting #{nets.count} IPv4Nets via NetAddr.sort_IPv4Net()."
+		assert_equal(expect, sorted)
+		sorted = NetAddr.sort_IPv4Net(nets.reverse)
+		assert_equal(expect, sorted)
 	end
 	
 	def test_summ_IPv4Net


### PR DESCRIPTION
Hi. I find your subnet summarizing methods really helpful. However, in my project, I had to refactor the code in a monkeypatch. This was necessary in order to be able to summarize large numbers of subnets. In my testing on my personal computer, 8000 subnets seemed enough to trigger the stack overflow.

This PR is a revised version of the monkeypatch code, adapted to make a proper PR, in case you want to consider the changes.

The code that was susceptible to the SystemStackError was the recursion in both `Util.quick_sort()` and `Util.discard_subnets()`. I was able to remove the recursion from discard_subnets(), and leverage built-in Ruby sorting to remove quick_sort() entirely.

A few notes:

* As written, `quick_sort()` could have handled Mask objects. However, the codebase never calls `quick_sort()` with a list of Masks, so I didn't change Masks to enable sorting.
* Summarizing 8k subnets takes about 30 seconds on my computer. I wrapped the test that summarizes 8k subnets in an environment variable check so that it doesn't run by default. That might be kind of a hacky solution.
* My project doesn't deal with IPv6 subnets. I have neither tried using IPv6 code paths in my project nor included IPv6/IPv6Net tests in this PR. (I can do so if you are interested.)

I'm happy to make changes to address any concerns you might have, if you do want to consider this PR for merging. Thanks for your work on this gem!