### PR TITLE
Add console script for instant experimentation

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "netaddr"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+require "irb"
+IRB.start(__FILE__)


### PR DESCRIPTION
The `bin/console` script starts a Ruby console with `netaddr` already loaded
so the developer can instantly experiment with the code.